### PR TITLE
:package: Explicitly declare dependency to `psr/http-message`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "nyholm/psr7": "^1.3",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",
+        "psr/http-message": "^1.0",
         "symfony/options-resolver": "^2.6 || ^3.4 || ^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Restrict the installed version to `v1` because the package compatible only with `v1`

Without declared dependency for now composer installs `psr/http-message` and it leads to the fatal error:
> PHP Fatal error:  Declaration of Http\Client\Socket\Stream::close() must be compatible with Psr\Http\Message\StreamInterface::close(): void in /.../vendor/code-tool/socket-client/src/Stream.php on line 78

To fix compatibility with `v2` it's needed to break BC for extended classes from `Stream`. See PR in upstream for example changes https://github.com/php-http/socket-client/pull/70